### PR TITLE
Update Dockerfile

### DIFF
--- a/TensorFlow/LanguageModeling/BERT/Dockerfile
+++ b/TensorFlow/LanguageModeling/BERT/Dockerfile
@@ -4,7 +4,7 @@ FROM tensorrtserver_client as trt
 
 FROM ${FROM_IMAGE_NAME}
 
-RUN apt-get update && apt-get install -y pbzip2 pv bzip2
+RUN apt-get update && apt-get install -y pbzip2 pv bzip2 libcurl3
 
 RUN pip install toposort networkx pytest nltk tqdm html2text progressbar
 


### PR DESCRIPTION
add libcurl3 install required by python when importing tensorrtserver.api module